### PR TITLE
Modifying Init Containers

### DIFF
--- a/kubernetes/lookit/base/patches_/wait-init-gcloud-sqlproxy.yaml
+++ b/kubernetes/lookit/base/patches_/wait-init-gcloud-sqlproxy.yaml
@@ -2,11 +2,9 @@
   path: /spec/template/spec/initContainers/-
   value:
     name: wait-init-gcloud-sqlproxy
-    image: bitnami/kubectl:latest
-    args: [
-      "rollout",
-      "status",
-      "deployment",
-      "-w",
-      "$(GCLOUD_SQLPROXY_DEPLOYMENT_NAME)"
-    ]
+    image: postgres:9.6
+    command:
+    - bash
+    args: 
+    - -c
+    - until pg_isready -h $(GCLOUD_SQLPROXY_SERVICE_NAME); do sleep 5; done

--- a/kubernetes/lookit/base/patches_/wait-init-gcloud-sqlproxy.yaml
+++ b/kubernetes/lookit/base/patches_/wait-init-gcloud-sqlproxy.yaml
@@ -7,4 +7,4 @@
     - bash
     args: 
     - -c
-    - until pg_isready -h $(GCLOUD_SQLPROXY_SERVICE_NAME); do sleep 5; done
+    - until pg_isready -h $(GCLOUD_SQLPROXY_SERVICE_NAME); do echo waiting for sqlproxy; sleep 5; done

--- a/kubernetes/lookit/base/patches_/wait-init-rabbitmq.yaml
+++ b/kubernetes/lookit/base/patches_/wait-init-rabbitmq.yaml
@@ -2,11 +2,6 @@
   path: /spec/template/spec/initContainers/-
   value:
     name: wait-init-rabbitmq
-    image: bitnami/kubectl:latest
-    args: [
-      "rollout",
-      "status",
-      "statefulset",
-      "-w",
-      "$(RABBITMQ_STATEFULSET_NAME)"
-    ]
+    image: busybox
+    command: ["sh", "-c"]
+    args: ["until nc -vn rabbitmq:5672; do echo waiting for rabbitmq; sleep 2; done"]

--- a/kubernetes/lookit/base/patches_/wait-init-rabbitmq.yaml
+++ b/kubernetes/lookit/base/patches_/wait-init-rabbitmq.yaml
@@ -4,4 +4,4 @@
     name: wait-init-rabbitmq
     image: busybox
     command: ["sh", "-c"]
-    args: ["until nc -vn rabbitmq:5672; do echo waiting for rabbitmq; sleep 2; done"]
+    args: ["until nc -vn $(RABBITMQ_SERVICE_NAME):5672; do echo waiting for rabbitmq; sleep 2; done"]

--- a/kubernetes/lookit/base/rabbitmq/statefulset.yaml
+++ b/kubernetes/lookit/base/rabbitmq/statefulset.yaml
@@ -95,6 +95,11 @@ spec:
           periodSeconds: 30
           failureThreshold: 3
           successThreshold: 1
+        startupProbe:
+          tcpSocket:
+            port: 5672
+          initialDelaySeconds: 5
+          periodSeconds: 5
         env:
           - name: BITNAMI_DEBUG
             value: "false"


### PR DESCRIPTION
This pull changes the init containers used to wait for both Cloud SQL Proxy and RabbitMQ to start up on the cluster. The previous implementation utilized the kubectl deploy command which does not guarantee service availability.

The SQL Proxy init container now uses pg_isready to confirm when the database connection is ready. The RabbitMQ init container now uses netcat to wait until RabbitMQ is responding on port 5672.

Resolves: #5 & #6