### PR TITLE
Remove resource requests from workload YAML

### DIFF
--- a/kubernetes/lookit/base/beat/beat-deployment.yaml
+++ b/kubernetes/lookit/base/beat/beat-deployment.yaml
@@ -11,14 +11,7 @@ spec:
     matchLabels: {}
   template:
     spec:
-      initContainers: 
-      - name: init-sqlproxy
-        image: busybox:1.33
-        command:
-        - /bin/sh
-        args:
-        - -c
-        - for i in {1..100}; do sleep 1; if dig $(SQLPROXY_SERVICE_NAME); exit 0; fi; exit 1
+      initContainers: []
       containers:
       - name: beat
         image: lookit

--- a/kubernetes/lookit/base/beat/beat-deployment.yaml
+++ b/kubernetes/lookit/base/beat/beat-deployment.yaml
@@ -38,9 +38,6 @@ spec:
           limits:
             cpu: "1"
             memory: 1Gi
-          requests:
-            cpu: 10m
-            memory: 128Mi
         volumeMounts:
         - mountPath: /etc/googleAppCreds.json
           name: secret-volume

--- a/kubernetes/lookit/base/beat/kustomization.yaml
+++ b/kubernetes/lookit/base/beat/kustomization.yaml
@@ -3,11 +3,3 @@ resources:
 commonLabels:
   app.kubernetes.io/name: beat
   app.kubernetes.io/component: celery-task-cron
-vars:
-- name: SQLPROXY_SERVICE_NAME
-  objref:
-    kind: Service
-    name: gcloud-sqlproxy
-    apiVersion: v1
-  fieldref:
-    fieldpath: metadata.name

--- a/kubernetes/lookit/base/builder/builder-statefulset.yaml
+++ b/kubernetes/lookit/base/builder/builder-statefulset.yaml
@@ -65,9 +65,6 @@ spec:
           limits:
             cpu: "2"
             memory: 4Gi
-          requests:
-            cpu: 10m
-            memory: 128Mi
         volumeMounts:
         - name: checkouts-volume
           mountPath: /code/ember_build/checkouts

--- a/kubernetes/lookit/base/cloudsql/cloudsql-deployment.yaml
+++ b/kubernetes/lookit/base/cloudsql/cloudsql-deployment.yaml
@@ -27,9 +27,6 @@ spec:
           limits:
             cpu: 150m
             memory: 150Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
         name: cloud-sqlproxy
         ports:
         - containerPort: 5432

--- a/kubernetes/lookit/base/files_/uwsgi.ini
+++ b/kubernetes/lookit/base/files_/uwsgi.ini
@@ -1,4 +1,5 @@
 [uwsgi]
+socket = :5000
 uid = www-data
 gid = www-data
 # add user-agent, http://uwsgi.unbit.narkive.com/jEtphIzE/default-log-format-explained#post5

--- a/kubernetes/lookit/base/rabbitmq/statefulset.yaml
+++ b/kubernetes/lookit/base/rabbitmq/statefulset.yaml
@@ -49,10 +49,6 @@ spec:
             #replace the default password that is generated
             sed -i "/CHANGEME/cdefault_pass=${RABBITMQ_PASSWORD//\\/\\\\}" /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
             exec rabbitmq-server
-        resources:
-          requests:
-            cpu: 100m
-            memory: 256Mi
         volumeMounts:
           - name: config-volume
             mountPath: /opt/bitnami/rabbitmq/conf

--- a/kubernetes/lookit/base/web/web-deployment.yaml
+++ b/kubernetes/lookit/base/web/web-deployment.yaml
@@ -42,9 +42,6 @@ spec:
           limits:
             cpu: "1"
             memory: 1Gi
-          requests:
-            cpu: 10m
-            memory: 128Mi
         volumeMounts:
         - mountPath: /etc/uwsgi/uwsgi.ini
           name: config-volume

--- a/kubernetes/lookit/base/web/web-deployment.yaml
+++ b/kubernetes/lookit/base/web/web-deployment.yaml
@@ -19,8 +19,6 @@ spec:
         - uwsgi
         - --ini
         - /etc/uwsgi/uwsgi.ini
-        - --socket
-        - :5000
         env: []
         ports:
         - containerPort: 5000

--- a/kubernetes/lookit/base/worker/worker-deployment.yaml
+++ b/kubernetes/lookit/base/worker/worker-deployment.yaml
@@ -39,9 +39,6 @@ spec:
           limits:
             cpu: "2"
             memory: 1Gi
-          requests:
-            cpu: 10m
-            memory: 128Mi
         volumeMounts:
         - mountPath: /etc/googleAppCreds.json
           name: secret-volume


### PR DESCRIPTION
Resource requests in excess of allocatable capacity have caused scheduling issues when there is a pod surge during deployment. This PR removes all CPU and Memory resource requests from the YAML files. Without a defined resource request the workloads will default to a 5m CPU and 5Mi memory request, which will provide sufficient headroom in CPU allocation to prevent further scheduling resource issues on deployments.