### PR TITLE
Add compile messages job config

### DIFF
--- a/kubernetes/lookit/base/compilemessages/compilemessages-job.yaml
+++ b/kubernetes/lookit/base/compilemessages/compilemessages-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: compilemessages
+  annotations:
+    lookit-env-vars: "injected"
+    wait-for-gcloud-sqlproxy: "true"
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 6
+  template:
+    metadata:
+      name: compilemessages
+    spec:
+      initContainers: []
+      containers:
+      - name: compilemessages
+        image: lookit
+        imagePullPolicy: IfNotPresent
+        command:
+        - python
+        - manage.py
+        - compilemessages
+        env: []
+        volumeMounts:
+        - mountPath: /etc/googleAppCreds.json
+          name: secret-volume
+          readOnly: true
+          subPath: googleAppCreds.json
+      restartPolicy: OnFailure
+      volumes:
+      - name: config-volume
+        configMap:
+          defaultMode: 420
+          name: lookit-configmap
+      - name: secret-volume
+        secret:
+          defaultMode: 420
+          secretName: lookit-secrets
+      - name: cloudsql-instance-credentials
+        secret:
+          defaultMode: 420
+          secretName: cloudsql-instance-credentials

--- a/kubernetes/lookit/base/compilemessages/kustomization.yaml
+++ b/kubernetes/lookit/base/compilemessages/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - compilemessages-job.yaml
+commonLabels:
+  app.kubernetes.io/name: compilemessages
+  app.kubernetes.io/component: compile-translation-messages

--- a/kubernetes/lookit/base/kustomization.template.yaml
+++ b/kubernetes/lookit/base/kustomization.template.yaml
@@ -7,6 +7,7 @@ resources:
 - builder
 - collectstatic
 - migration
+- compilemessages
 - web
 - worker
 - google-cloud-storage


### PR DESCRIPTION
Job to run `python manage.py compilemessages`.  Once we've confirmed this is working as intended, we'll need to remove the *.mo files from lookit-api.  

I added @jtrouth as a reviewer as this is my first kustomization config.  I basically copied the collectstatic config.  

Closes #8