### PR TITLE
Update env values to support second domain

### DIFF
--- a/kubernetes/lookit/environments/production/lookit-config.env
+++ b/kubernetes/lookit/environments/production/lookit-config.env
@@ -1,5 +1,5 @@
 ACCOUNT_LOGOUT_REDIRECT_URL=/login/
-ALLOWED_HOSTS=lookit.mit.edu
+ALLOWED_HOSTS=lookit.mit.edu childrenhelpingscience.com
 BASE_URL=https://lookit.mit.edu
 CLOUDSQL_INSTANCE_CONNECTION_NAME=mit-lookit:us-east1:production
 CORS_ORIGIN_ALLOW_ALL=
@@ -21,6 +21,6 @@ OSF_API_URL=https://api.osf.io
 OSF_URL=https://osf.io/
 PREVIEW_EXPERIMENT_BASE_URL=https://storage.googleapis.com/lookit-production/preview_experiments/
 SITE_DOMAIN=lookit.mit.edu
-SECONDARY_DOMAIN=lookit.mit.edu
+SECONDARY_DOMAIN=childrenhelpingscience.com
 STATIC_URL=https://storage.googleapis.com/lookit-production/static/
 CLUSTER_ISSUER=production-acme-cluster-issuer


### PR DESCRIPTION
This PR adds the `childrenhelpingscience.com` domain to environment variables.  This should generate the ssl cert and allow Django to service the additional domain.  