### PR TITLE
Remove section for versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,6 @@ or develop branches will automatically trigger a build with the correct tag, com
 
 ## Endnotes
 
-### Versioning
-
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags). 
-
 ### Authors
 
 * **Rico Rodriguez** ([Datamance](https://github.com/Datamance))


### PR DESCRIPTION
The section in the readme pertaining to versioning is outdated. We no longer implement semantic versioning.  There is nothing wrong with semantic versioning, it just didn't add any value to the project.  

This PR removes the versioning section in the readme.  