### PR TITLE
Update celery option "max-tasks-per-child"

### DIFF
--- a/kubernetes/lookit/base/builder/builder-statefulset.yaml
+++ b/kubernetes/lookit/base/builder/builder-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         - -n
         - worker.%h
         - --without-gossip
-        - --maxtasksperchild
+        - --max-tasks-per-child
         - "1"
         - -Q
         - builds,cleanup

--- a/kubernetes/lookit/base/worker/worker-deployment.yaml
+++ b/kubernetes/lookit/base/worker/worker-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - -n
         - worker.%h
         - --without-gossip
-        - --maxtasksperchild
+        - --max-tasks-per-child
         - "5"
         - -Q
         - email


### PR DESCRIPTION
# Summary

Celery changed the option "--maxtasksperchild" to "--max-tasks-per-child".  This PR updates that option. 